### PR TITLE
Fix shiftOutputs() method: exclude burn payments.

### DIFF
--- a/Transaction.js
+++ b/Transaction.js
@@ -133,7 +133,9 @@ Transaction.prototype.allowRules = function () {
 Transaction.prototype.shiftOutputs = function (shiftAmount) {
   shiftAmount = shiftAmount || 1
   this.payments.forEach(function (payment) {
-    payment.output += shiftAmount
+    if (!payment.burn) {
+      payment.output += shiftAmount
+    }
   })
 }
 


### PR DESCRIPTION
This change fixes an issue where 'output' property was being added to burn payment entries by accident, which in turn caused an error in cc-transfer-encoder when trying to encode the payments due to the presence of both properties 'burn' and 'output' in a single payment entry.